### PR TITLE
Wrap msg in a ValueListenableBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,7 @@
 ## [1.0.3] - 15.08.2021
 
 * Bug fix
+
+## [1.0.4] - 24.08.2021
+
+* Fix message not updating if you set the value to 0.

--- a/lib/progress_dialog.dart
+++ b/lib/progress_dialog.dart
@@ -152,15 +152,20 @@ class ProgressDialog {
                             top: 8.0,
                             bottom: 8.0,
                           ),
-                          child: Text(
-                            _msg.value,
-                            maxLines: msgMaxLines,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              fontSize: msgFontSize,
-                              color: msgColor,
-                              fontWeight: FontWeight.bold,
-                            ),
+                          child: ValueListenableBuilder(
+                            valueListenable: _msg,
+                            builder: (context, value, child) {
+                              return Text(
+                                _msg.value,
+                                maxLines: msgMaxLines,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  fontSize: msgFontSize,
+                                  color: msgColor,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              );
+                            },
                           ),
                         ),
                       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sn_progress_dialog
 description: Customizable progress dialog package for Flutter.(Captures the progress value)
-version: 1.0.3
+version: 1.0.4
 author: A.Emre ESEN <emreesen27@gmail.com>
 homepage: https://github.com/emreesen27/Flutter-Progress-Dialog.git
 


### PR DESCRIPTION
This fixes the message not changing if you're only updating the message
and setting the progress to 0.

Since the ValueListener of the progress is initialized as 0, nothing
happens if you change the message and keep the progress as 0.