### PR TITLE
_dialogIsOpen flag out of sync fixing

### DIFF
--- a/lib/progress_dialog.dart
+++ b/lib/progress_dialog.dart
@@ -220,9 +220,12 @@ class ProgressDialog {
             },
           ),
         ),
-        onWillPop: () => Future.value(
-          barrierDismissible,
-        ),
+        onWillPop: (){
+          if(barrierDismissible){
+            _dialogIsOpen = false;
+          }
+          return Future.value(barrierDismissible);
+        },
       ),
     );
   }


### PR DESCRIPTION
_dialogIsOpen flag out of sync when barrierDismissible is true, and progressdialog.close() cause Navigator.pop() executed on dismissed dialog