### PR TITLE
Migrate to material_ui package

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -9,7 +9,7 @@ jobs:
   package-analysis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: axel-op/dart-package-analyzer@v3
         # set an id for the current step
         id: analysis

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,4 @@
+analyzer:
+  exclude:
+    - build/**
 include: package:flutter_lints/flutter.yaml

--- a/example/README.md
+++ b/example/README.md
@@ -1,7 +1,7 @@
 # Sn Progress Dialog Example
 
 ```dart
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sn_progress_dialog/sn_progress_dialog.dart';
 
 void main() {

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,1 +1,6 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
 include: package:flutter_lints/flutter.yaml

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sn_progress_dialog/sn_progress_dialog.dart';
 
 void main() {
@@ -6,18 +6,16 @@ void main() {
 }
 
 class MyExample extends StatelessWidget {
-  const MyExample({Key? key}) : super(key: key);
+  const MyExample({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Home(),
-    );
+    return MaterialApp(home: Home());
   }
 }
 
 class Home extends StatelessWidget {
-  const Home({Key? key}) : super(key: key);
+  const Home({super.key});
 
   Future<void> _indeterminateProgress(dynamic context) async {
     /// Create progress dialog
@@ -82,14 +80,15 @@ class Home extends StatelessWidget {
   Future<void> _customProgress(dynamic context) async {
     ProgressDialog pd = ProgressDialog(context: context);
     pd.show(
-        max: 100,
-        msg: 'Preparing Download...',
-        progressType: ProgressType.determinate,
-        backgroundColor: Color(0xff212121),
-        progressValueColor: Color(0xff3550B4),
-        progressBgColor: Colors.white70,
-        msgStyle: TextStyle(color: Colors.white),
-        valueStyle: TextStyle(color: Colors.white));
+      max: 100,
+      msg: 'Preparing Download...',
+      progressType: ProgressType.determinate,
+      backgroundColor: Color(0xff212121),
+      progressValueColor: Color(0xff3550B4),
+      progressBgColor: Colors.white70,
+      msgStyle: TextStyle(color: Colors.white),
+      valueStyle: TextStyle(color: Colors.white),
+    );
     await Future.delayed(Duration(milliseconds: 3000));
     for (int i = 0; i <= 100; i++) {
       pd.update(value: i, msg: 'File Downloading...');
@@ -164,54 +163,58 @@ class Home extends StatelessWidget {
               padding: const EdgeInsets.all(20.0),
               child: Text(
                 'Sn Progress Example',
-                style: TextStyle(
-                  fontSize: 30.0,
-                  fontWeight: FontWeight.bold,
-                ),
+                style: TextStyle(fontSize: 30.0, fontWeight: FontWeight.bold),
               ),
             ),
             MaterialButton(
-                color: Color(0xfff7f7f7),
-                child: Text('Indeterminate Progress'),
-                onPressed: () {
-                  _indeterminateProgress(context);
-                }),
+              color: Color(0xfff7f7f7),
+              child: Text('Indeterminate Progress'),
+              onPressed: () {
+                _indeterminateProgress(context);
+              },
+            ),
             MaterialButton(
-                color: Color(0xfff7f7f7),
-                child: Text('Determinate Progress'),
-                onPressed: () {
-                  _determinateProgress(context);
-                }),
+              color: Color(0xfff7f7f7),
+              child: Text('Determinate Progress'),
+              onPressed: () {
+                _determinateProgress(context);
+              },
+            ),
             MaterialButton(
-                color: Color(0xfff7f7f7),
-                child: Text('Preparing Progress'),
-                onPressed: () {
-                  _preparingProgress(context);
-                }),
+              color: Color(0xfff7f7f7),
+              child: Text('Preparing Progress'),
+              onPressed: () {
+                _preparingProgress(context);
+              },
+            ),
             MaterialButton(
-                color: Color(0xfff7f7f7),
-                child: Text('Custom Progress'),
-                onPressed: () {
-                  _customProgress(context);
-                }),
+              color: Color(0xfff7f7f7),
+              child: Text('Custom Progress'),
+              onPressed: () {
+                _customProgress(context);
+              },
+            ),
             MaterialButton(
-                color: Color(0xfff7f7f7),
-                child: Text('Completed Progress'),
-                onPressed: () {
-                  _completedProgress(context);
-                }),
+              color: Color(0xfff7f7f7),
+              child: Text('Completed Progress'),
+              onPressed: () {
+                _completedProgress(context);
+              },
+            ),
             MaterialButton(
-                color: Color(0xfff7f7f7),
-                child: Text('Message Progress'),
-                onPressed: () {
-                  _onlyMessageProgress(context);
-                }),
+              color: Color(0xfff7f7f7),
+              child: Text('Message Progress'),
+              onPressed: () {
+                _onlyMessageProgress(context);
+              },
+            ),
             MaterialButton(
-                color: Color(0xfff7f7f7),
-                child: Text('Message Progress With Completed'),
-                onPressed: () {
-                  _onlyMessageWithCompletionProgress(context);
-                }),
+              color: Color(0xfff7f7f7),
+              child: Text('Message Progress With Completed'),
+              onPressed: () {
+                _onlyMessageWithCompletionProgress(context);
+              },
+            ),
           ],
         ),
       ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: e51d50bca3217c9a9fa2b41a30e4a38971133f5f9ec7a3d57bae095007f1d28e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   collection:
     dependency: transitive
     description:
@@ -25,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  cupertino_ui:
+    dependency: transitive
+    description:
+      name: cupertino_ui
+      sha256: e9dfe7fac704028f8928cbe4028a0be5e8a709498e8daf8247de99e99a32aef3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -38,6 +54,19 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.3"
   lints:
     dependency: transitive
     description:
@@ -50,18 +79,34 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: "9c0156b0cf8b3f56d365c8ffe051a720be3cae9eec55119f01e01b986ffb7101"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.19.0"
+  path:
+    dependency: transitive
+    description:
+      name: path
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -78,10 +123,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.47.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -128,5 +128,5 @@ packages:
     source: hosted
     version: "2.4.2"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
+  dart: ">=3.13.0 <4.0.0"
   flutter: ">=3.47.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,11 +18,12 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
+  material_ui: ^1.1.1
   sn_progress_dialog:
     path: ../
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.12.0 <4.0.0"
+  sdk: ">=3.13.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/lib/enums/dialog_status.dart
+++ b/lib/enums/dialog_status.dart
@@ -7,5 +7,5 @@ enum DialogStatus {
   closed,
 
   /// Dialog has completed its progress
-  completed
+  completed,
 }

--- a/lib/enums/value_position.dart
+++ b/lib/enums/value_position.dart
@@ -4,5 +4,5 @@ enum ValuePosition {
   center,
 
   /// Right aligned progress value
-  right
+  right,
 }

--- a/lib/options/cancel.dart
+++ b/lib/options/cancel.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class Cancel {
   /// Callback function that will be executed when cancel button is tapped.

--- a/lib/options/completed.dart
+++ b/lib/options/completed.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class Completed {
   /// Future that resolves to the completion message.

--- a/lib/progress_dialog.dart
+++ b/lib/progress_dialog.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sn_progress_dialog/enums/dialog_status.dart';
 import 'package:sn_progress_dialog/enums/progress_types.dart';
 import 'package:sn_progress_dialog/enums/value_position.dart';
@@ -33,11 +33,10 @@ class ProgressDialog {
 
   /// Creates a progress dialog with the given build context.
   ///
-  /// [context] - Required build context for showing the dialog
+  /// [_context] - Required build context for showing the dialog
   /// [useRootNavigator] - Whether to show in root navigator. Defaults to true
-  ProgressDialog({required BuildContext context, bool? useRootNavigator})
-      : _context = context,
-        _useRootNavigator = useRootNavigator ?? true;
+  ProgressDialog({required this._context, bool? useRootNavigator})
+    : _useRootNavigator = useRootNavigator ?? true;
 
   /// Updates the dialog's progress value and message.
   ///
@@ -89,8 +88,11 @@ class ProgressDialog {
   }
 
   /// Creates a progress indicator with deterministic value.
-  CircularProgressIndicator _valueProgress(
-      {Color? valueColor, Color? bgColor, required double value}) {
+  CircularProgressIndicator _valueProgress({
+    Color? valueColor,
+    Color? bgColor,
+    required double value,
+  }) {
     return CircularProgressIndicator(
       backgroundColor: bgColor,
       valueColor: AlwaysStoppedAnimation<Color?>(valueColor),
@@ -99,8 +101,10 @@ class ProgressDialog {
   }
 
   /// Creates an indeterminate progress indicator.
-  CircularProgressIndicator _normalProgress(
-      {Color? valueColor, Color? bgColor}) {
+  CircularProgressIndicator _normalProgress({
+    Color? valueColor,
+    Color? bgColor,
+  }) {
     return CircularProgressIndicator(
       backgroundColor: bgColor,
       valueColor: AlwaysStoppedAnimation<Color?>(valueColor),
@@ -187,9 +191,7 @@ class ProgressDialog {
           backgroundColor: backgroundColor,
           elevation: elevation,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(
-              Radius.circular(borderRadius),
-            ),
+            borderRadius: BorderRadius.all(Radius.circular(borderRadius)),
           ),
           content: ValueListenableBuilder(
             valueListenable: _progress,
@@ -221,7 +223,8 @@ class ProgressDialog {
                                 width: cancel.cancelImageSize,
                                 height: cancel.cancelImageSize,
                                 color: cancel.cancelImageColor,
-                                image: cancel.cancelImage ??
+                                image:
+                                    cancel.cancelImage ??
                                     AssetImage(
                                       "images/cancel.png",
                                       package: "sn_progress_dialog",
@@ -236,7 +239,8 @@ class ProgressDialog {
                           ? Image(
                               width: 40,
                               height: 40,
-                              image: completed.completedImage ??
+                              image:
+                                  completed.completedImage ??
                                   AssetImage(
                                     "images/completed.png",
                                     package: "sn_progress_dialog",
@@ -251,15 +255,15 @@ class ProgressDialog {
                                       valueColor: progressValueColor,
                                     )
                                   : value == 0
-                                      ? _normalProgress(
-                                          bgColor: progressBgColor,
-                                          valueColor: progressValueColor,
-                                        )
-                                      : _valueProgress(
-                                          valueColor: progressValueColor,
-                                          bgColor: progressBgColor,
-                                          value: (value / max) * 100,
-                                        ),
+                                  ? _normalProgress(
+                                      bgColor: progressBgColor,
+                                      valueColor: progressValueColor,
+                                    )
+                                  : _valueProgress(
+                                      valueColor: progressValueColor,
+                                      bgColor: progressBgColor,
+                                      value: (value / max) * 100,
+                                    ),
                             ),
                       Expanded(
                         child: Padding(
@@ -270,23 +274,28 @@ class ProgressDialog {
                           ),
                           child: ValueListenableBuilder(
                             valueListenable: _msg,
-                            builder: (BuildContext context, dynamic msgValue,
-                                Widget? child) {
-                              return ValueListenableBuilder(
-                                valueListenable: _completedMsg,
-                                builder: (context, completedMsgValue, child) {
-                                  return Text(
-                                    value == max && completed != null
-                                        ? completedMsgValue
-                                        : msgValue,
-                                    textAlign: msgTextAlign,
-                                    maxLines: msgMaxLines,
-                                    overflow: TextOverflow.ellipsis,
-                                    style: msgStyle,
+                            builder:
+                                (
+                                  BuildContext context,
+                                  dynamic msgValue,
+                                  Widget? child,
+                                ) {
+                                  return ValueListenableBuilder(
+                                    valueListenable: _completedMsg,
+                                    builder:
+                                        (context, completedMsgValue, child) {
+                                          return Text(
+                                            value == max && completed != null
+                                                ? completedMsgValue
+                                                : msgValue,
+                                            textAlign: msgTextAlign,
+                                            maxLines: msgMaxLines,
+                                            overflow: TextOverflow.ellipsis,
+                                            style: msgStyle,
+                                          );
+                                        },
                                   );
                                 },
-                              );
-                            },
                           ),
                         ),
                       ),
@@ -298,14 +307,16 @@ class ProgressDialog {
                               ? Alignment.bottomRight
                               : Alignment.bottomCenter,
                           child: Text(
-                              value <= 0 ? '' : '${_progress.value}/$max',
-                              style: (valueStyle ?? TextStyle(inherit: true))
-                                  .copyWith(
-                                      decoration: value == max
-                                          ? TextDecoration.lineThrough
-                                          : TextDecoration.none)),
+                            value <= 0 ? '' : '${_progress.value}/$max',
+                            style: (valueStyle ?? TextStyle(inherit: true))
+                                .copyWith(
+                                  decoration: value == max
+                                      ? TextDecoration.lineThrough
+                                      : TextDecoration.none,
+                                ),
+                          ),
                         )
-                      : SizedBox.shrink()
+                      : SizedBox.shrink(),
                 ],
               );
             },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,5 +113,5 @@ packages:
     source: hosted
     version: "2.4.2"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
+  dart: ">=3.13.0 <4.0.0"
   flutter: ">=3.47.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: e51d50bca3217c9a9fa2b41a30e4a38971133f5f9ec7a3d57bae095007f1d28e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   collection:
     dependency: transitive
     description:
@@ -17,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cupertino_ui:
+    dependency: transitive
+    description:
+      name: cupertino_ui
+      sha256: e9dfe7fac704028f8928cbe4028a0be5e8a709498e8daf8247de99e99a32aef3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -30,6 +46,19 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.3"
   lints:
     dependency: transitive
     description:
@@ -42,18 +71,34 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: "9c0156b0cf8b3f56d365c8ffe051a720be3cae9eec55119f01e01b986ffb7101"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.19.0"
+  path:
+    dependency: transitive
+    description:
+      name: path
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -63,10 +108,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.47.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.0
 homepage: https://github.com/emreesen27/Flutter-Progress-Dialog
 
 environment:
-  sdk: '>=3.12.0 <4.0.0'
+  sdk: '>=3.13.0 <4.0.0'
   flutter: '>=3.47.0'
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,13 @@ version: 2.0.0
 homepage: https://github.com/emreesen27/Flutter-Progress-Dialog
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
-  flutter: '>=3.0.0'
+  sdk: '>=3.12.0 <4.0.0'
+  flutter: '>=3.47.0'
 
 dependencies:
   flutter:
     sdk: flutter
+  material_ui: ^1.1.1
 
 dev_dependencies:
   flutter_lints: ^6.0.0


### PR DESCRIPTION
Flutter is currently in a transition phase to the decoupled `material_ui` package. This already migrates this package before the migration becomes mandatory and this package can no longer be used.
If you want to publish this change, Flutter (once again) suggests to use a major version bump (i.e., to publish this as version 3.0.0 of `sn_progress_dialog`)